### PR TITLE
Redefining storage items for agreements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d3b15875ba253d1110c740755e246537483f152fa334f91abd7fe84c88b3ff"
+checksum = "6afaa937395a620e33dc6a742c593c01aced20aa376ffb0f628121198578ccc7"
 dependencies = [
  "async-lock 3.2.0",
  "cfg-if",
@@ -639,7 +639,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -776,7 +776,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -1216,7 +1216,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -1642,7 +1642,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -1669,7 +1669,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -1686,7 +1686,7 @@ checksum = "587663dd5fb3d10932c8aecfe7c844db1bcf0aee93eeab08fac13dc1212c2e7f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -1956,7 +1956,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -1997,7 +1997,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.39",
+ "syn 2.0.40",
  "termcolor",
  "toml 0.8.2",
  "walkdir",
@@ -2219,7 +2219,7 @@ dependencies = [
  "fs-err",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -2564,7 +2564,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-core-hashing",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -2576,7 +2576,7 @@ dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -2586,7 +2586,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -2736,7 +2736,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -3662,9 +3662,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libloading"
@@ -4289,7 +4289,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -4303,7 +4303,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -4314,7 +4314,7 @@ checksum = "9ea73aa640dc01d62a590d48c0c3521ed739d53b27f919b25c3551e233481654"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -4325,7 +4325,7 @@ checksum = "ef9d79ae96aaba821963320eb2b6e34d17df1e5a83d8a1985c29cc5be59577b3"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -5254,7 +5254,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -5295,7 +5295,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -5440,7 +5440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -5508,7 +5508,7 @@ checksum = "9b698b0b09d40e9b7c1a47b132d66a8b54bcd20583d9b6d06e4535e383b4405c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -5554,7 +5554,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -5866,7 +5866,7 @@ checksum = "7f7473c2cfcf90008193dd0e3e16599455cb601a9fce322b5bb55de799664925"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -6275,7 +6275,7 @@ dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -7105,7 +7105,7 @@ dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -7356,7 +7356,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -7604,7 +7604,7 @@ dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -7830,13 +7830,13 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot
 dependencies = [
  "quote",
  "sp-core-hashing",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.4.1"
-source = "git+https://github.com/paritytech/polkadot-sdk#f6ae145813b2e213b39f09f713d3ccbdd9376f6b"
+source = "git+https://github.com/paritytech/polkadot-sdk#6b5995ffd162d88df1e3baeaafe05869d1a7d966"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -7870,17 +7870,17 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#f6ae145813b2e213b39f09f713d3ccbdd9376f6b"
+source = "git+https://github.com/paritytech/polkadot-sdk#6b5995ffd162d88df1e3baeaafe05869d1a7d966"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -7897,7 +7897,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#f6ae145813b2e213b39f09f713d3ccbdd9376f6b"
+source = "git+https://github.com/paritytech/polkadot-sdk#6b5995ffd162d88df1e3baeaafe05869d1a7d966"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -8082,7 +8082,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#f6ae145813b2e213b39f09f713d3ccbdd9376f6b"
+source = "git+https://github.com/paritytech/polkadot-sdk#6b5995ffd162d88df1e3baeaafe05869d1a7d966"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -8106,20 +8106,20 @@ dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#f6ae145813b2e213b39f09f713d3ccbdd9376f6b"
+source = "git+https://github.com/paritytech/polkadot-sdk#6b5995ffd162d88df1e3baeaafe05869d1a7d966"
 dependencies = [
  "Inflector",
  "expander",
  "proc-macro-crate 2.0.1",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -8204,7 +8204,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot
 [[package]]
 name = "sp-std"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#f6ae145813b2e213b39f09f713d3ccbdd9376f6b"
+source = "git+https://github.com/paritytech/polkadot-sdk#6b5995ffd162d88df1e3baeaafe05869d1a7d966"
 
 [[package]]
 name = "sp-storage"
@@ -8222,7 +8222,7 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#f6ae145813b2e213b39f09f713d3ccbdd9376f6b"
+source = "git+https://github.com/paritytech/polkadot-sdk#6b5995ffd162d88df1e3baeaafe05869d1a7d966"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8260,7 +8260,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#f6ae145813b2e213b39f09f713d3ccbdd9376f6b"
+source = "git+https://github.com/paritytech/polkadot-sdk#6b5995ffd162d88df1e3baeaafe05869d1a7d966"
 dependencies = [
  "parity-scale-codec",
  "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
@@ -8342,7 +8342,7 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -8361,7 +8361,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#f6ae145813b2e213b39f09f713d3ccbdd9376f6b"
+source = "git+https://github.com/paritytech/polkadot-sdk#6b5995ffd162d88df1e3baeaafe05869d1a7d966"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -8518,7 +8518,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -8626,9 +8626,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "13fa70a4ee923979ffb522cacce59d34421ebdea5625e1073c4326ef9d2dd42e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8735,7 +8735,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -8853,7 +8853,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -9033,7 +9033,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -9436,7 +9436,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
  "wasm-bindgen-shared",
 ]
 
@@ -9470,7 +9470,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -10063,9 +10063,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.26"
+version = "0.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67b5f0a4e7a27a64c651977932b9dc5667ca7fc31ac44b03ed37a0cf42fdfff"
+checksum = "6c830786f7720c2fd27a1a0e27a709dbd3c4d009b56d098fc742d4f4eab91fe2"
 dependencies = [
  "memchr",
 ]
@@ -10170,7 +10170,7 @@ checksum = "be912bf68235a88fbefd1b73415cb218405958d1655b2ece9035a19920bdf6ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -10190,7 +10190,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]

--- a/pallets/deitos/src/lib.rs
+++ b/pallets/deitos/src/lib.rs
@@ -90,6 +90,9 @@ pub mod pallet {
         type MaxAgreements: Get<u32>;
 
         #[pallet::constant]
+        type MaxAgreementsPerConsumer: Get<u32>;
+
+        #[pallet::constant]
         type PalletId: Get<PalletId>;
     }
 
@@ -135,13 +138,21 @@ pub mod pallet {
 
     #[pallet::storage]
     #[pallet::getter(fn agreements)]
-    pub(super) type Agreements<T: Config> = StorageDoubleMap<
+    pub(super) type Agreements<T: Config> = StorageMap<
+        _,
+        Blake2_128Concat,
+        T::AgreementId,
+        AgreementDetails<T>,
+        ResultQuery<Error<T>::NonExistentStorageValue>,
+    >;
+
+    #[pallet::storage]
+    #[pallet::getter(fn consumer_agreement)]
+    pub(super) type ConsumerAgreements<T: Config> = StorageMap<
         _,
         Blake2_128Concat,
         T::AccountId, // Consumer
-        Blake2_128Concat,
-        T::AccountId, // Provider
-        AgreementDetails<T>,
+        AgreementsPerConsumer<T>,
         ResultQuery<Error<T>::NonExistentStorageValue>,
     >;
 

--- a/pallets/deitos/src/mock.rs
+++ b/pallets/deitos/src/mock.rs
@@ -85,6 +85,7 @@ impl pallet_deitos::Config for Test {
     type AgreementId = u32;
     type MaxPaymentPlanDuration = ConstU32<500>;
     type MaxAgreements = ConstU32<500>;
+    type MaxAgreementsPerConsumer = ConstU32<500>;
     type PalletId = DeitosPalletId;
 }
 

--- a/pallets/deitos/src/types.rs
+++ b/pallets/deitos/src/types.rs
@@ -74,7 +74,6 @@ pub struct IPDetails<T: pallet::Config> {
 #[scale_info(skip_type_params(T))]
 #[codec(mel_bound(T: pallet::Config))]
 pub struct AgreementDetails<T: pallet::Config> {
-    pub id: T::AgreementId,
     // Agreement Status
     pub status: AgreementStatus,
     // Total amount of storage in the agreement expressed in bytes?

--- a/pallets/deitos/src/types.rs
+++ b/pallets/deitos/src/types.rs
@@ -14,6 +14,8 @@ pub type Installment<T> = BalanceOf<T>;
 pub type PaymentsDetails<T> = (Installment<T>, PaymentPlanPeriods);
 pub type PaymentPlan<T> = BoundedVec<PaymentsDetails<T>, <T as Config>::MaxPaymentPlanDuration>;
 pub type ActiveAgreements<T> = BoundedVec<<T as Config>::AgreementId, <T as Config>::MaxAgreements>;
+pub type AgreementsPerConsumer<T> =
+    BoundedVec<<T as Config>::AgreementId, <T as Config>::MaxAgreementsPerConsumer>;
 
 // TODO: Review the necessary status.
 #[derive(Clone, Encode, Decode, Eq, PartialEq, MaxEncodedLen, TypeInfo, Debug)]

--- a/runtime/src/deitos.rs
+++ b/runtime/src/deitos.rs
@@ -15,6 +15,7 @@ impl pallet_deitos::Config for Runtime {
     type AgreementId = AgreementId;
     type MaxPaymentPlanDuration = ConstU32<500>;
     type MaxAgreements = ConstU32<500>;
+    type MaxAgreementsPerConsumer = ConstU32<500>;
     type PalletId = DeitosPalletId;
     type WeightInfo = pallet_deitos::weights::SubstrateWeight<Runtime>;
 }


### PR DESCRIPTION
The new logical organization for the Storage Items are the following:

AgreementId => AgreementDetails;
consumer => boundedVec<agreementId>
ip -> IPDetails { active_agreements: boundedVec<agreementId>}

