### PR TITLE
Payments

### DIFF
--- a/pallets/deitos/src/tests/agreements.rs
+++ b/pallets/deitos/src/tests/agreements.rs
@@ -104,7 +104,7 @@ fn test_ip_accept_agreement() {
 
         // Verify that the agreement status is correctly updated
         let stored_agreement = Agreements::<Test>::get(agreement_id).unwrap();
-        assert_eq!(stored_agreement.status, AgreementStatus::Agreed);
+        assert_eq!(stored_agreement.status, AgreementStatus::Active);
 
         // Check for the correct event emission
         System::assert_has_event(RuntimeEvent::Deitos(Event::IPAcceptedAgreement {
@@ -121,6 +121,7 @@ fn test_consumer_accept_agreement() {
         let storage: StorageSizeMB = 100;
         let activation_block: BlockNumberFor<Test> = 100;
         let payment_plan: PaymentPlan<Test> = vec![activation_block + 300].try_into().unwrap();
+        let initial_consumer_deposit = 300 * PRICE_STORAGE;
 
         // Register and activate the IP
         register_and_activate_ip(IP, storage);
@@ -156,7 +157,7 @@ fn test_consumer_accept_agreement() {
         let expected_consumer_deposit = 200 * PRICE_STORAGE; // Length of last installment * price per block
         let stored_agreement = Agreements::<Test>::get(agreement_id).unwrap();
         assert_eq!(stored_agreement.consumer_deposit, expected_consumer_deposit);
-        assert_eq!(stored_agreement.status, AgreementStatus::Agreed);
+        assert_eq!(stored_agreement.status, AgreementStatus::Active);
         assert_eq!(stored_agreement.payment_plan, new_payment_plan);
 
         // Verify that the consumer's balance is properly updated
@@ -178,6 +179,8 @@ fn test_consumer_accept_agreement() {
             agreement_id,
             ip: IP,
             consumer: CONSUMER,
+            consumer_deposit_released: initial_consumer_deposit,
+            consumer_deposit_held: expected_consumer_deposit,
         }));
     });
 }
@@ -188,6 +191,7 @@ fn consumer_reject_proposal() {
         let storage: StorageSizeMB = 100;
         let activation_block: BlockNumberFor<Test> = 100;
         let payment_plan: PaymentPlan<Test> = vec![activation_block + 300].try_into().unwrap();
+        let consumer_deposit = 300 * PRICE_STORAGE;
 
         // Register and activate the IP
         register_and_activate_ip(IP, storage);
@@ -246,6 +250,7 @@ fn consumer_reject_proposal() {
             agreement_id,
             ip: IP,
             consumer: CONSUMER,
+            consumer_deposit,
         }));
     });
 }

--- a/pallets/deitos/src/tests/mod.rs
+++ b/pallets/deitos/src/tests/mod.rs
@@ -1,5 +1,7 @@
 use frame_support::{
-    assert_ok, parameter_types,
+    assert_ok,
+    pallet_prelude::*,
+    parameter_types,
     traits::{ConstU32, ConstU64},
     PalletId,
 };
@@ -128,11 +130,13 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
     ext
 }
 
-#[allow(dead_code)]
 pub fn run_to_block(n: u64) {
-    // TODO: Might need to trigger hooks too
     while System::block_number() < n {
+        if System::block_number() > 1 {
+            System::on_finalize(System::block_number());
+        }
         System::set_block_number(System::block_number() + 1);
+        System::on_initialize(System::block_number());
     }
 }
 

--- a/pallets/deitos/src/tests/payments.rs
+++ b/pallets/deitos/src/tests/payments.rs
@@ -1,0 +1,143 @@
+use frame_support::{assert_noop, traits::fungible};
+use frame_system::pallet_prelude::BlockNumberFor;
+
+use crate::{
+    pallet::{Agreements, Error, Event, HoldReason},
+    types::*,
+};
+
+use super::*;
+
+#[test]
+fn test_consumer_prepay_installment() {
+    new_test_ext().execute_with(|| {
+        let storage: StorageSizeMB = 100;
+        let activation_block: BlockNumberFor<Test> = 100;
+        let payment_plan: PaymentPlan<Test> = vec![activation_block + 100, activation_block + 300]
+            .try_into()
+            .unwrap();
+
+        register_and_activate_ip(IP, storage);
+        let agreement_id = create_accepted_agreement(
+            IP,
+            CONSUMER,
+            storage,
+            activation_block,
+            payment_plan.clone(),
+        );
+
+        let installment_cost = 100 * PRICE_STORAGE;
+        let balance_before = Balances::free_balance(CONSUMER);
+
+        // Consumer prepays the first installment
+        assert_ok!(Deitos::consumer_prepay_installment(
+            RuntimeOrigin::signed(CONSUMER),
+            agreement_id,
+        ));
+
+        // Verify that the agreement is correctly updated
+        let stored_agreement = Agreements::<Test>::get(agreement_id).unwrap();
+        assert_eq!(
+            stored_agreement.payment_history,
+            vec![PaymentRecord {
+                amount: installment_cost,
+                transferred: false
+            }]
+        );
+
+        // Verify that the consumer's balance is properly updated
+        assert_eq!(
+            Balances::free_balance(CONSUMER),
+            balance_before - installment_cost
+        );
+
+        assert_eq!(
+            <Balances as fungible::InspectHold<_>>::balance_on_hold(
+                &HoldReason::ConsumerInstallment.into(),
+                &CONSUMER
+            ),
+            installment_cost
+        );
+
+        // Check for the correct event emission
+        System::assert_has_event(RuntimeEvent::Deitos(Event::ConsumerPrepaidInstallment {
+            agreement_id,
+            ip: IP,
+            consumer: CONSUMER,
+            cost: installment_cost,
+        }));
+    });
+}
+
+#[test]
+fn test_consumer_prepay_multiple() {
+    new_test_ext().execute_with(|| {
+        let storage: StorageSizeMB = 100;
+        let activation_block: BlockNumberFor<Test> = 100;
+        let payment_plan: PaymentPlan<Test> = vec![
+            activation_block + 100,
+            activation_block + 300,
+            activation_block + 600,
+        ]
+        .try_into()
+        .unwrap();
+
+        register_and_activate_ip(IP, storage);
+        let agreement_id = create_accepted_agreement(
+            IP,
+            CONSUMER,
+            storage,
+            activation_block,
+            payment_plan.clone(),
+        );
+
+        let balance_before = Balances::free_balance(CONSUMER);
+
+        // Consumer prepays the first installment
+        assert_ok!(Deitos::consumer_prepay_installment(
+            RuntimeOrigin::signed(CONSUMER),
+            agreement_id,
+        ));
+
+        // Consumer prepays the second installment
+        assert_ok!(Deitos::consumer_prepay_installment(
+            RuntimeOrigin::signed(CONSUMER),
+            agreement_id,
+        ));
+
+        // Verify that the agreement is correctly updated
+        let expected_payment_history = vec![
+            PaymentRecord {
+                amount: 100 * PRICE_STORAGE,
+                transferred: false,
+            },
+            PaymentRecord {
+                amount: 200 * PRICE_STORAGE,
+                transferred: false,
+            },
+        ];
+        let stored_agreement = Agreements::<Test>::get(agreement_id).unwrap();
+        assert_eq!(stored_agreement.payment_history, expected_payment_history);
+
+        // Verify that the consumer's balance is properly updated
+        let total_cost = 300 * PRICE_STORAGE;
+        assert_eq!(
+            Balances::free_balance(CONSUMER),
+            balance_before - total_cost
+        );
+
+        assert_eq!(
+            <Balances as fungible::InspectHold<_>>::balance_on_hold(
+                &HoldReason::ConsumerInstallment.into(),
+                &CONSUMER
+            ),
+            total_cost
+        );
+
+        // Verify that consumer cannot prepay any more installments
+        assert_noop!(
+            Deitos::consumer_prepay_installment(RuntimeOrigin::signed(CONSUMER), agreement_id),
+            Error::<Test>::NoMoreInstallments
+        );
+    });
+}

--- a/pallets/deitos/src/tests/payments.rs
+++ b/pallets/deitos/src/tests/payments.rs
@@ -38,7 +38,7 @@ fn test_consumer_prepay_installment() {
         // Verify that the agreement is correctly updated
         let stored_agreement = Agreements::<Test>::get(agreement_id).unwrap();
         assert_eq!(
-            stored_agreement.payment_history,
+            stored_agreement.payment_history.records,
             vec![PaymentRecord {
                 amount: installment_cost,
                 transferred: false
@@ -62,7 +62,6 @@ fn test_consumer_prepay_installment() {
         // Check for the correct event emission
         System::assert_has_event(RuntimeEvent::Deitos(Event::ConsumerPrepaidInstallment {
             agreement_id,
-            ip: IP,
             consumer: CONSUMER,
             cost: installment_cost,
         }));
@@ -106,7 +105,7 @@ fn test_consumer_prepay_multiple() {
         ));
 
         // Verify that the agreement is correctly updated
-        let expected_payment_history = vec![
+        let expected_payment_records = vec![
             PaymentRecord {
                 amount: 100 * PRICE_STORAGE,
                 transferred: false,
@@ -117,7 +116,10 @@ fn test_consumer_prepay_multiple() {
             },
         ];
         let stored_agreement = Agreements::<Test>::get(agreement_id).unwrap();
-        assert_eq!(stored_agreement.payment_history, expected_payment_history);
+        assert_eq!(
+            stored_agreement.payment_history.records,
+            expected_payment_records
+        );
 
         // Verify that the consumer's balance is properly updated
         let total_cost = 300 * PRICE_STORAGE;
@@ -139,5 +141,162 @@ fn test_consumer_prepay_multiple() {
             Deitos::consumer_prepay_installment(RuntimeOrigin::signed(CONSUMER), agreement_id),
             Error::<Test>::NoMoreInstallments
         );
+    });
+}
+
+#[test]
+fn test_ip_withdraw() {
+    new_test_ext().execute_with(|| {
+        let storage: StorageSizeMB = 100;
+        let activation_block: BlockNumberFor<Test> = 100;
+        let payment_plan: PaymentPlan<Test> = vec![
+            activation_block + 100,
+            activation_block + 300,
+            activation_block + 600,
+        ]
+        .try_into()
+        .unwrap();
+
+        register_and_activate_ip(IP, storage);
+        let agreement_id = create_accepted_agreement(
+            IP,
+            CONSUMER,
+            storage,
+            activation_block,
+            payment_plan.clone(),
+        );
+
+        // Consumer prepays the first installment
+        assert_ok!(Deitos::consumer_prepay_installment(
+            RuntimeOrigin::signed(CONSUMER),
+            agreement_id,
+        ));
+
+        // Consumer prepays the second installment
+        assert_ok!(Deitos::consumer_prepay_installment(
+            RuntimeOrigin::signed(CONSUMER),
+            agreement_id,
+        ));
+
+        let balance_before = Balances::free_balance(IP);
+
+        // IP withdraws the first installment (the second one is not yet due)
+        run_to_block(activation_block + 101);
+        assert_ok!(Deitos::ip_withdraw_installments(
+            RuntimeOrigin::signed(IP),
+            agreement_id,
+        ));
+
+        // Verify that the agreement is correctly updated
+        let expected_payment_records = vec![
+            PaymentRecord {
+                amount: 100 * PRICE_STORAGE,
+                transferred: true,
+            },
+            PaymentRecord {
+                amount: 200 * PRICE_STORAGE,
+                transferred: false,
+            },
+        ];
+        let stored_agreement = Agreements::<Test>::get(agreement_id).unwrap();
+        assert_eq!(
+            stored_agreement.payment_history.records,
+            expected_payment_records
+        );
+        assert_eq!(
+            stored_agreement
+                .payment_history
+                .next_transfer_installment_index,
+            1
+        );
+
+        // Verify that the IP's balance is properly updated
+        let total_cost = 100 * PRICE_STORAGE;
+        assert_eq!(Balances::free_balance(IP), balance_before + total_cost);
+
+        //Verify that the consumer's balance is properly updated
+        assert_eq!(
+            <Balances as fungible::InspectHold<_>>::balance_on_hold(
+                &HoldReason::ConsumerInstallment.into(),
+                &CONSUMER
+            ),
+            200 * PRICE_STORAGE
+        );
+
+        // Check for the correct event emission
+        System::assert_has_event(RuntimeEvent::Deitos(Event::IPWithdrewInstallments {
+            agreement_id,
+            ip: IP,
+            transferred: total_cost,
+        }));
+    });
+}
+
+#[test]
+fn test_ip_withdraw_completely() {
+    new_test_ext().execute_with(|| {
+        let storage: StorageSizeMB = 100;
+        let activation_block: BlockNumberFor<Test> = 100;
+        let payment_plan: PaymentPlan<Test> = vec![
+            activation_block + 100,
+            activation_block + 300,
+            activation_block + 600,
+        ]
+        .try_into()
+        .unwrap();
+
+        register_and_activate_ip(IP, storage);
+        let agreement_id = create_accepted_agreement(
+            IP,
+            CONSUMER,
+            storage,
+            activation_block,
+            payment_plan.clone(),
+        );
+
+        // Consumer prepays the first installment
+        assert_ok!(Deitos::consumer_prepay_installment(
+            RuntimeOrigin::signed(CONSUMER),
+            agreement_id,
+        ));
+
+        // Consumer prepays the second installment
+        assert_ok!(Deitos::consumer_prepay_installment(
+            RuntimeOrigin::signed(CONSUMER),
+            agreement_id,
+        ));
+
+        let balance_before = Balances::free_balance(IP);
+
+        // IP withdraws all installments
+        run_to_block(activation_block + 601);
+        assert_ok!(Deitos::ip_withdraw_installments(
+            RuntimeOrigin::signed(IP),
+            agreement_id,
+        ));
+
+        // Verify that the agreement is correctly updated
+        let stored_agreement = Agreements::<Test>::get(agreement_id).unwrap();
+        assert!(stored_agreement.all_transfers_completed());
+        assert_eq!(stored_agreement.status, AgreementStatus::Completed);
+
+        // Verify that the IP's balance is properly updated
+        let total_cost = 600 * PRICE_STORAGE;
+        assert_eq!(Balances::free_balance(IP), balance_before + total_cost);
+
+        //Verify that the consumer's balance is properly updated
+        assert_eq!(
+            <Balances as fungible::InspectHold<_>>::balance_on_hold(
+                &HoldReason::ConsumerInstallment.into(),
+                &CONSUMER
+            ),
+            0
+        );
+
+        // Check for the correct event emission
+        System::assert_has_event(RuntimeEvent::Deitos(Event::AgreementStatusChanged {
+            agreement_id,
+            status: AgreementStatus::Completed,
+        }));
     });
 }

--- a/pallets/deitos/src/weights.rs
+++ b/pallets/deitos/src/weights.rs
@@ -45,7 +45,7 @@ pub trait WeightInfo {
 	fn ip_propose_payment_plan() -> Weight;
 	fn consumer_accept_agreement() -> Weight;
 	fn consumer_prepay_installment() -> Weight;
-	fn withdraw_provider_funds() -> Weight;
+	fn ip_withdraw_installments() -> Weight;
 	fn submit_provider_feedback() -> Weight;	
 	fn submit_consumer_feedback() -> Weight;
 
@@ -155,7 +155,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 
-	fn withdraw_provider_funds() -> Weight {
+	fn ip_withdraw_installments() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
@@ -299,7 +299,7 @@ impl WeightInfo for () {
 	}
 		/// Storage: Deitos Something (r:0 w:1)
 	/// Proof: Deitos Something (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
-	fn withdraw_provider_funds() -> Weight {
+	fn ip_withdraw_installments() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`

--- a/pallets/deitos/src/weights.rs
+++ b/pallets/deitos/src/weights.rs
@@ -46,7 +46,7 @@ pub trait WeightInfo {
 	fn consumer_accept_agreement() -> Weight;
 	fn consumer_prepay_installment() -> Weight;
 	fn ip_withdraw_installments() -> Weight;
-	fn submit_provider_feedback() -> Weight;	
+	fn ip_terminate_nonpay() -> Weight;
 	fn submit_consumer_feedback() -> Weight;
 
 }
@@ -164,7 +164,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 
-	fn submit_provider_feedback() -> Weight {
+	fn ip_terminate_nonpay() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
@@ -309,7 +309,7 @@ impl WeightInfo for () {
 	}
 		/// Storage: Deitos Something (r:0 w:1)
 	/// Proof: Deitos Something (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
-	fn submit_provider_feedback() -> Weight {
+	fn ip_terminate_nonpay() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`

--- a/pallets/deitos/src/weights.rs
+++ b/pallets/deitos/src/weights.rs
@@ -44,7 +44,7 @@ pub trait WeightInfo {
 	fn ip_accept_agreement() -> Weight;
 	fn ip_propose_payment_plan() -> Weight;
 	fn consumer_accept_agreement() -> Weight;
-	fn make_installment_payment() -> Weight;
+	fn consumer_prepay_installment() -> Weight;
 	fn withdraw_provider_funds() -> Weight;
 	fn submit_provider_feedback() -> Weight;	
 	fn submit_consumer_feedback() -> Weight;
@@ -146,7 +146,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 
-	fn make_installment_payment() -> Weight {
+	fn consumer_prepay_installment() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
@@ -289,7 +289,7 @@ impl WeightInfo for () {
 	}
 		/// Storage: Deitos Something (r:0 w:1)
 	/// Proof: Deitos Something (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
-	fn make_installment_payment() -> Weight {
+	fn consumer_prepay_installment() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`


### PR DESCRIPTION
Implementation of payments.

3 new transactions added:
1. `consumer_prepay_installment` - allows consumers to prepay the next installment. Installment should be prepaid before the start on the next installment. Every transaction call prepays one more installment, allowing to prepay as much as wanted.
2. `ip_withdraw_installments` - allows IPs to withdraw complete installments. The transaction automatically checks for all payments that can be withdrawn. If all of the payments were withdrawn the agreement status changes to `Complete`.
3. `ip_terminate_nonpay` - allows IPs to terminate an agreement due to non-payment. It automatically transfers all the payments available, transfer the deposit and removes the agreement.