### PR TITLE
Fix unknown feature `stdsimd`

### DIFF
--- a/.github/workflows/publish-artifact.yml
+++ b/.github/workflows/publish-artifact.yml
@@ -1,4 +1,4 @@
-name: Workflow - upload to artifacts
+name: Workflow - Upload to artifacts
 
 on:
   workflow_dispatch:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-02-01"
 components = [
 	"cargo",
 	"clippy",


### PR DESCRIPTION
Latest nightly toolchain removed feature `stdsimd`, which is used in `ahash` crate. A temporary solution is to downgrade rust toolchain version. 

Later the problem should be fixed with polkadot upgrade (the problem was fixed in ahash version 0.8)